### PR TITLE
recommend 723studio.fta-ruleset-tools instead openxcomfta.ruleset-tools

### DIFF
--- a/src/extensionRecommender.ts
+++ b/src/extensionRecommender.ts
@@ -51,7 +51,7 @@ export class ExtensionRecommender {
 
         if ('ftaGame' in variables && variables.ftaGame === true) {
             this.recommend(
-                'openxcomfta.ruleset-tools',
+                '723studio.fta-ruleset-tools',
                 'noRecommendOpenXcomFtaRulesetTools',
                 'Install the OpenXCOM FtA Ruleset Tools extension to improve QoL even more! This provides syntax validation on the rule files.'
             );


### PR DESCRIPTION
As fta ruleset tools was moved to another publisher, please, change recommended extension as existing one is outdated